### PR TITLE
Update surefire plugin version and declare system property variable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
 				<configuration>
 					<forkCount>3</forkCount>
 					<reuseForks>true</reuseForks>
-					<argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+					<argLine>@{argLine} -Xmx1024m -XX:MaxPermSize=256m</argLine>
 					<systemPropertyVariables>
 						<mavenSurefireForkNumber>id-${surefire.forkNumber}</mavenSurefireForkNumber>
 					</systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -209,12 +209,14 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<!-- <version>2.21.0</version> -->
-				<version>2.12.4</version>
+				<version>2.22.2</version>
 				<configuration>
 					<forkCount>3</forkCount>
 					<reuseForks>true</reuseForks>
 					<argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+					<systemPropertyVariables>
+						<mavenSurefireForkNumber>id-${surefire.forkNumber}</mavenSurefireForkNumber>
+					</systemPropertyVariables>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
Bump `maven-surefire-plugin` version from `2.12.4` to `2.22.2` in order to allow execution of JaCoCo plugin.
Declare a system property variable `mavenSurefireForkNumber` to be reused in tests to avoid concurrency issues (on files and folders write operation) when executing tests with several JVM in parallel (i.e. `forkCount` > 1).

**Important:** this will break the build until related pull request created on [telosys-tools-commons](https://github.com/telosys-tools-bricks/telosys-tools-commons/pull/4) and [telosys-tools-api](https://github.com/telosys-tools-bricks/telosys-tools-api/pull/4) are merged 