### PR TITLE
Fix JaCoCo property inclusion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<!-- <skip-license>true</skip-license> -->
+		<argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
 	</properties>
 
 	<modules>
@@ -227,7 +228,6 @@
 						Error occurred in starting fork
 					<argLine>@{argLine} -Xmx1024m -XX:MaxPermSize=256m</argLine>
 					-->
-					<argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine> <!-- OK -->
 					<!-- 
 					<systemPropertyVariables>
 						<mavenSurefireForkNumber>id-${surefire.forkNumber}</mavenSurefireForkNumber>


### PR DESCRIPTION
JVM property required by JaCoCo need to be defined when executing tests. This is documented in https://www.jacoco.org/jacoco/trunk/doc/prepare-agent-mojo.html.

This PR should replace PR #3 because surefire plugin version has been already update in master and only 1 VM is now used for tests execution (`<forkCount>` is no longer set and default value is 1).